### PR TITLE
Fix to allow windows to build package

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "author": "Fredrik Makila",
   "license": "MIT",
   "scripts": {
-    "build": "./node_modules/typescript/bin/tsc",
+    "build": "node node_modules/typescript/bin/tsc",
     "test": "jest",
     "lint": "eslint '*.{js,ts}' '*/**/*.{js,ts}' --ignore-pattern '/dist/*'",
     "release": "standard-version",


### PR DESCRIPTION
Little adjustment - I was checking my project can build on windows (that has rosz2js as a dependency) and noticed it doesn't build on windows.  Easy change though.